### PR TITLE
Use concatMap and from in records operator instead of flatMap

### DIFF
--- a/src/handlers.js
+++ b/src/handlers.js
@@ -1,9 +1,9 @@
 const rxjs = require('rxjs');
-const { filter, flatMap, map, mergeAll, share, throwIfEmpty } = require('rxjs/operators');
+const { filter, concatMap, map, mergeAll, share, throwIfEmpty } = require('rxjs/operators');
 
 exports.records = () => rxjs.pipe(
   filter((event) => event.hasOwnProperty('Records')),
-  flatMap(({ Records }) => Records)
+  concatMap(({ Records }) => rxjs.from(Records))
 );
 
 exports.some = (...operatorFactories) => async (event, context) => {


### PR DESCRIPTION
Even though the behavior of this new implementation appears exactly the same, there were two things that scare me about the old implementation:

1. `flatMap` is a synonym for `mergeMap` which means concurrent processing of the `Observables`. Because streams like Kinesis are order dependent, I wanted to use an operator like `concatMap` which preserves ordering.

2. The result from the function used in both `concatMap` and `flatMap` is supposed to return an `Observable`. The previous implementation was counting on some undocumented coercion from an Array to an Observable that emits the elements. Better to be explicit and match the documented types.