### PR TITLE
fix: add correlation id

### DIFF
--- a/src/dynamo-streams.test.ts
+++ b/src/dynamo-streams.test.ts
@@ -399,17 +399,10 @@ describe('DynamoStreamHandler', () => {
       logger,
       unmarshall: testSerializer.unmarshall,
       createRunContext: (ctx) => {
-        ctx.logger.info(
-          { correlationId: ctx.correlationId },
-          'createRunContext',
-        );
+        expect(typeof ctx.correlationId === 'string').toBe(true);
         return {};
       },
-    })
-      .onInsert((ctx) => {
-        ctx.logger.info({ correlationId: ctx.correlationId }, 'insert');
-      })
-      .harness({ marshall: () => ({}) });
+    }).harness({ marshall: () => ({}) });
 
     await sendEvent({ records: [] });
 
@@ -417,15 +410,7 @@ describe('DynamoStreamHandler', () => {
       expect.objectContaining({ correlationId: expect.any(String) }),
     );
 
-    expect(logger.info).toHaveBeenCalledWith(
-      { correlationId: expect.any(String) },
-      'createRunContext',
-    );
-
-    expect(logger.info).toHaveBeenCalledWith(
-      { correlationId: expect.any(String) },
-      'insert',
-    );
+    expect.assertions(2);
   });
 
   describe('error scenarios', () => {

--- a/src/dynamo-streams.ts
+++ b/src/dynamo-streams.ts
@@ -1,8 +1,10 @@
 import { LoggerInterface } from '@lifeomic/logging';
+import { v4 as uuid } from 'uuid';
 import { DynamoDBStreamEvent, DynamoDBStreamHandler } from 'aws-lambda';
 
 export type BaseContext = {
   logger: LoggerInterface;
+  correlationId: string;
 };
 
 export type DynamoStreamHandlerConfig<Entity, Context> = {
@@ -164,9 +166,14 @@ export class DynamoStreamHandler<Entity, Context> {
           body: JSON.stringify({ healthy: true }),
         } as unknown as void;
       }
+      const correlationId = uuid();
 
       const base: BaseContext = {
-        logger: this.config.logger.child({ requestID: ctx.awsRequestId }),
+        correlationId,
+        logger: this.config.logger.child({
+          requestID: ctx.awsRequestId,
+          correlationId,
+        }),
       };
 
       const context: BaseContext & Context = {


### PR DESCRIPTION
## Motivation
Having a pre-generated correlation id is very nice for interacting with other downstream services.