### PR TITLE
feat: support non-http health checks

### DIFF
--- a/src/dynamo-streams.test.ts
+++ b/src/dynamo-streams.test.ts
@@ -46,6 +46,24 @@ describe('DynamoStreamHandler', () => {
     });
   });
 
+  test('responds to healthCheck events', async () => {
+    const lambda = new DynamoStreamHandler({
+      logger,
+      unmarshall: testSerializer.unmarshall,
+      createRunContext: () => ({}),
+    }).lambda();
+
+    const result = await lambda(
+      { healthCheck: true } as any,
+      {} as any,
+      {} as any,
+    );
+
+    expect(result).toStrictEqual({
+      healthy: true,
+    });
+  });
+
   test('handles insert events', async () => {
     const lambda = new DynamoStreamHandler({
       logger,

--- a/src/dynamo-streams.ts
+++ b/src/dynamo-streams.ts
@@ -159,13 +159,18 @@ export class DynamoStreamHandler<Entity, Context> {
    */
   lambda(): DynamoDBStreamHandler {
     return async (event, ctx) => {
-      // 1. Handle the health check.
+      // 1. Handle potential health checks.
       if ((event as any).httpMethod) {
         return {
           statusCode: 200,
           body: JSON.stringify({ healthy: true }),
         } as unknown as void;
       }
+
+      if ((event as any).healthCheck) {
+        return { healthy: true } as any;
+      }
+
       const correlationId = uuid();
 
       const base: BaseContext = {


### PR DESCRIPTION
## Motivation
When troubleshooting [this Slack thread](https://lifeomic.slack.com/archives/C3NA7J4E8/p1647440047138359), I realized that this library currently only supports HTTP event health checks -- a weird pattern, though it's the common one in `connect-service`.

Just adding support for the more idiomatic health check "event" pattern.