### PR TITLE
docs: correct docs until we have a better 'harness' context solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ export const handler = stream.lambda();
 `DynamoStreamHelper` also comes with a nice helper for testing: `harness(...)`
 
 ```typescript
+const context = {
+  doSomething: jest.fn()
+}
+
 const harness = stream.harness({
   marshall: () => {
     /* marshall from your custom type -> stream format */
@@ -70,6 +74,7 @@ const harness = stream.harness({
   logger,
   createRunContext: () => {
     /* optionally override the context, to mock e.g. data sources */
+    return context;
   }
 })
 
@@ -84,7 +89,6 @@ test('something', async () => {
     ]
   })
 
-  // Also provides access to the underlying run context for assertions + mocking
-  expect(harness.context.dataSources.doSomething).toHaveBeenCalled()
+  expect(context.dataSources.doSomething).toHaveBeenCalled()
 })
 ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ const stream = new DynamoStreamHandler({
     entity.id;
 
     // `ctx` contains the nice result of `createRunContext`
-    await ctx.dataSources.doSomething();
+    await ctx.doSomething();
 
     // `ctx` contains a logger by default, which already includes niceties like
     // the AWS request id
@@ -89,6 +89,6 @@ test('something', async () => {
     ]
   })
 
-  expect(context.dataSources.doSomething).toHaveBeenCalled()
+  expect(context.doSomething).toHaveBeenCalled()
 })
 ```


### PR DESCRIPTION
## Motivation
The docs are incorrect about `context` being accessible on the test harness. It'd better to have a more complete solution for returning the mock context in the "harness", but that's a bigger change than I have time for at the moment.

This at least corrects the docs with a basic working example.