### PR TITLE
fix: copy member for obfuscation

### DIFF
--- a/src/dynamo-streams.ts
+++ b/src/dynamo-streams.ts
@@ -19,7 +19,8 @@ export type DynamoStreamHandlerConfig<Entity, Context> = {
   logger: LoggerInterface;
   /**
    * A listing of keys within a dynamo record's images to obfuscate in logging
-   * output.
+   * output. This will not perform a deep obfuscation of 'M' AttributeValue
+   * types and instead will simply obfuscate the entire value.
    */
   loggerObfuscateImageKeys?: string[];
   /**
@@ -137,13 +138,13 @@ export class DynamoStreamHandler<Entity, Context> {
 
   private obfuscate(blob: any, keys: string[]): any {
     if (blob === undefined) return undefined;
-    const obfuscated = blob;
+    const copy: any = { ...blob };
     keys.forEach((k) => {
-      if (obfuscated[k]) {
-        obfuscated[k] = { S: 'obfuscated' };
+      if (copy[k]) {
+        copy[k] = { S: 'obfuscated' };
       }
     });
-    return obfuscated;
+    return copy;
   }
 
   private obfuscateRecord(dynamoRecord: DynamoDBRecord): DynamoDBRecord {


### PR DESCRIPTION
Fix for the discovered but of modifying the actual dynamo event data. Also added test coverage for the discovered issue with a nest Map AttributeValue type to go beyond just strings.