### PR TITLE
fix: use external aggregate-error package to get better messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@aws-sdk/util-dynamodb": "^3.369.0",
     "@types/aws-lambda": "^8.10.92",
+    "aggregate-error": "^3.0.0",
     "lodash": "^4.17.21",
     "p-map": "^4.0.0",
     "uuid": "^8.3.2"

--- a/src/dynamo-streams.test.ts
+++ b/src/dynamo-streams.test.ts
@@ -114,11 +114,8 @@ describe('DynamoStreamHandler', () => {
         {} as any,
       );
     } catch (e: any) {
-      expect(e).toBeInstanceOf(AggregateError);
-      expect(e.errors).toEqual([
-        new Error('Failed to process new-insert-2'),
-        new Error('Failed to process new-insert-3'),
-      ]);
+      expect(e.message).toContain('Failed to process new-insert-2');
+      expect(e.message).toContain('Failed to process new-insert-3');
     }
 
     expect(dataSources.doSomething).toHaveBeenCalledTimes(1);

--- a/src/kinesis.test.ts
+++ b/src/kinesis.test.ts
@@ -267,11 +267,8 @@ describe('KinesisEventHandler', () => {
           {} as any,
         );
       } catch (e: any) {
-        expect(e).toBeInstanceOf(AggregateError);
-        expect(e.errors).toEqual([
-          new Error('Failed to process test-event-2'),
-          new Error('Failed to process test-event-3'),
-        ]);
+        expect(e.message).toContain('Failed to process test-event-2');
+        expect(e.message).toContain('Failed to process test-event-3');
       }
     });
 

--- a/src/sqs.test.ts
+++ b/src/sqs.test.ts
@@ -337,11 +337,12 @@ describe('SQSMessageHandler', () => {
           {} as any,
         );
       } catch (e: any) {
-        expect(e).toBeInstanceOf(AggregateError);
-        expect(e.errors).toEqual([
-          new Error('Failed to process message test-event-3'),
-          new Error('Failed to process message test-event-7'),
-        ]);
+        expect(e.message).toContain(
+          'Error: Failed to process message test-event-3',
+        );
+        expect(e.message).toContain(
+          'Error: Failed to process message test-event-7',
+        );
       }
     });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,7 @@ import { LoggerInterface } from '@lifeomic/logging';
 import { Context } from 'aws-lambda';
 import pMap from 'p-map';
 import groupBy from 'lodash/groupBy';
+import AggregateError from 'aggregate-error';
 
 export type BaseContext = {
   logger: LoggerInterface;


### PR DESCRIPTION
## Motivation
Currently, we're using the NodeJS built-in `AggregateError`. We discovered today that this is problematic, because NodeJS does not include a useful `.message` field on `AggregateError` objects. So, when they are logged, there is no helpful data.

Using this external package gives us a more complete `message` field, and thus more useful errors.