### PR TITLE
fix: reference correct logger

### DIFF
--- a/src/dynamo-streams.ts
+++ b/src/dynamo-streams.ts
@@ -249,7 +249,7 @@ export class DynamoStreamHandler<Entity, Context> {
           concurrency: this.config.concurrency ?? 5,
         },
         async (record) => {
-          const recordLogger = this.config.logger.child({
+          const recordLogger = context.logger.child({
             record: this.obfuscateRecord(record),
           });
           if (!record.dynamodb) {


### PR DESCRIPTION
## Motivation
A bad reference slipped in a few months ago here. It was causing the correlationId and request id to be lost from the record-specific logger.