### PR TITLE
EOCI-213: [pt. 4] better error logging

### DIFF
--- a/src/dynamo-streams.test.ts
+++ b/src/dynamo-streams.test.ts
@@ -905,7 +905,7 @@ describe('DynamoStreamHandler', () => {
       // Expect that redaction is working
       expect(logger.error).toHaveBeenCalledWith(
         expect.objectContaining({
-          identifier: 'one',
+          itemIdentifier: 'one',
           failedRecord: {
             eventName: 'INSERT',
             dynamodb: {
@@ -926,7 +926,7 @@ describe('DynamoStreamHandler', () => {
       // expect that third event is logged
       expect(logger.error).toHaveBeenCalledWith(
         expect.objectContaining({
-          identifier: 'three',
+          itemIdentifier: 'three',
           failedRecord: {
             eventName: 'INSERT',
             dynamodb: {

--- a/src/kinesis.test.ts
+++ b/src/kinesis.test.ts
@@ -539,7 +539,7 @@ describe('KinesisEventHandler', () => {
       // Expect that first event is logged
       expect(logger.error).toHaveBeenCalledWith(
         expect.objectContaining({
-          identifier: 'one',
+          itemIdentifier: 'one',
           failedRecord: {
             kinesis: {
               sequenceNumber: 'one',
@@ -559,7 +559,7 @@ describe('KinesisEventHandler', () => {
       // Expect that third event is logged
       expect(logger.error).toHaveBeenCalledWith(
         expect.objectContaining({
-          identifier: 'three',
+          itemIdentifier: 'three',
           failedRecord: {
             kinesis: {
               sequenceNumber: 'three',

--- a/src/sqs.test.ts
+++ b/src/sqs.test.ts
@@ -371,7 +371,7 @@ describe('SQSMessageHandler', () => {
       // First failure group, expecting message bodies
       expect(logger.error).toHaveBeenCalledWith(
         expect.objectContaining({
-          identifier: 'message-3',
+          itemIdentifier: 'message-3',
           failedRecord: expect.objectContaining({
             body: JSON.stringify({
               name: `test-event-3`,
@@ -387,7 +387,7 @@ describe('SQSMessageHandler', () => {
       // Second failure group, expecting message bodies
       expect(logger.error).toHaveBeenCalledWith(
         expect.objectContaining({
-          identifier: 'message-7',
+          itemIdentifier: 'message-7',
           failedRecord: expect.objectContaining({
             body: JSON.stringify({
               name: `test-event-7`,
@@ -487,7 +487,7 @@ describe('SQSMessageHandler', () => {
       // First failure group, expecting message bodies are redacted
       expect(logger.error).toHaveBeenCalledWith(
         expect.objectContaining({
-          identifier: 'message-3',
+          itemIdentifier: 'message-3',
           failedRecord: expect.objectContaining({
             body: 'REDACTED',
             messageId: 'message-3',
@@ -502,7 +502,7 @@ describe('SQSMessageHandler', () => {
       // Second failure group, expecting message bodies are redacted
       expect(logger.error).toHaveBeenCalledWith(
         expect.objectContaining({
-          identifier: 'message-7',
+          itemIdentifier: 'message-7',
           failedRecord: expect.objectContaining({
             body: 'REDACTED',
             messageId: 'message-7',


### PR DESCRIPTION
# Motivations

This came from what I noticed while debugging the member scheduling issue. We weren't logging the errors correctly when using partial failure batches, and it was super hard to correlate sumo logs when looking for an issue.

Also slipped in a small improvement to reduce the number of times we iterated through the same unprocessed records list. Besides that, I think the code ends up being simpler.

Also used `itemIdentifier` when logging to make it obvious that that's what we use for partial batch failures.