### PR TITLE
Fix logger interface

### DIFF
--- a/build.js
+++ b/build.js
@@ -8,10 +8,6 @@ run('rm -rf dist/');
 
 run('yarn tsc');
 
-for (const file of ['package.json', 'README.md']) {
-  run(`cp ${file} dist/`);
-}
-
 // Remove test files from output
 for (const file of glob.sync('dist/**/*.test.*')) {
   unlinkSync(file);

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "lambda",
     "streams"
   ],
-  "main": "index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./jest-utils": "./dist/jest-utils.js"
+  },
   "scripts": {
     "lint": "eslint .",
     "test": "jest",

--- a/release.config.js
+++ b/release.config.js
@@ -2,7 +2,7 @@ module.exports = {
   branches: ['master'],
   plugins: [
     ['@semantic-release/commit-analyzer', { preset: 'conventionalcommits' }],
-    ['@semantic-release/npm', { pkgRoot: 'dist/' }],
+    ['@semantic-release/npm'],
     [
       '@semantic-release/github',
       {

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -2,5 +2,7 @@ import Logger from 'bunyan';
 
 export type LoggerInterface = Pick<
   Logger,
-  'child' | 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal'
->;
+  'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal'
+> & {
+  child: (...args: Parameters<Logger['child']>) => LoggerInterface;
+};


### PR DESCRIPTION
The logger interface was leaking the `bunyan` type through the `child` method. This can break consuming projects that don't use `bunyan` directly.