### PR TITLE
[FOTN-865]: add SNS message handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,19 @@ test('something', async () => {
 })
 ```
 
-### `SQSMessageHandler`
+### Message Handlers (SQS & SNS)
 
-This helper provides an abstraction over a SQS message Lambda handler.
+Both `SQSMessageHandler` and `SNSMessageHandler` provide a unified abstraction for processing message-based Lambda events. They share the same core functionality through a common base class, with only the underlying AWS event structure differing.
+
+#### Shared Configuration & Usage
+
+Both handlers support the same configuration options and API:
 
 ```typescript
-import { SQSMessageHandler } from '@lifeomic/delta';
+import { SQSMessageHandler, SNSMessageHandler } from '@lifeomic/delta';
 
-const queue = new SQSMessageHandler({
+// Same configuration for both handlers
+const config = {
   logger,
   parseMessage: (message) => {
     /* ... parse from message string -> your custom type ... */
@@ -113,57 +118,79 @@ const queue = new SQSMessageHandler({
   },
   // Optionally specify a concurrency setting for processing events.
   concurrency: 5,
-})
+};
+
+// Use with SQS
+const sqsHandler = new SQSMessageHandler(config)
   .onMessage(async (ctx, message) => {
     // `ctx` contains the nice result of `createRunContext`:
     await ctx.doSomething();
-
     // `ctx` contains a logger by default, which already includes niceties like
     // the AWS request id
-    ctx.logger.info('blah blah');
+    ctx.logger.info('processed SQS message');
   })
   // Add multiple message handlers for code organization.
   .onMessage(async (ctx, message) => {
     // do something else
   });
 
-// Provides a dead-simple API for creating the Lambda.
-export const handler = stream.lambda();
+// Or with SNS - identical API
+const snsHandler = new SNSMessageHandler(config)
+  .onMessage(async (ctx, message) => {
+    // `ctx` contains the nice result of `createRunContext`:
+    await ctx.doSomething();
+    // `ctx` contains a logger by default, which already includes niceties like
+    // the AWS request id
+    ctx.logger.info('processed SNS message');
+  })
+  // Add multiple message handlers for code organization.
+  .onMessage(async (ctx, message) => {
+    // do something else
+  });
+
+// Both provide the same lambda() method
+export const sqsLambda = sqsHandler.lambda();
+export const snsLambda = snsHandler.lambda();
 ```
 
-`SQSMessageHandler` also comes with a nice helper for testing: `harness(...)`
+#### Shared Testing Harness
+
+Both handlers provide identical testing harnesses:
 
 ```typescript
-const context = {
-  doSomething: jest.fn()
-}
+const context = { doSomething: jest.fn() };
 
-const harness = queue.harness({
-  stringifyMessage: (message) => {
-    /* stringify from your custom type -> string */
-    return JSON.stringify(message)
-  },
-  /* optionally override the logger */
+// Same harness API for both handlers
+const testConfig = {
+  stringifyMessage: (message) => JSON.stringify(message),
   logger,
-  createRunContext: () => {
-    /* optionally override the context, to mock e.g. data sources */
-    return context;
-  }
-})
+  createRunContext: () => context,
+};
 
-test('something', async () => {
-  // Provides a simple `sendEvent` function
-  await harness.sendEvent({
-    messages: [
-      { /* message 1 */}
-      { /* message 2 */}
-      { /* message 3 */}
-    ]
-  })
+const sqsHarness = sqsHandler.harness(testConfig);
+const snsHarness = snsHandler.harness(testConfig);
 
-  expect(context.doSomething).toHaveBeenCalledTimes(3)
-})
+test('SQS messages', async () => {
+  await sqsHarness.sendEvent({
+    messages: [{ id: 1 }, { id: 2 }],
+  });
+  expect(context.doSomething).toHaveBeenCalledTimes(2);
+});
+
+test('SNS messages', async () => {
+  await snsHarness.sendEvent({
+    messages: [{ id: 1 }, { id: 2 }],
+  });
+  expect(context.doSomething).toHaveBeenCalledTimes(2);
+});
 ```
+
+#### Key Differences
+
+- **`SQSMessageHandler`**: Processes SQS queue messages, uses `MessageGroupId` for ordering
+- **`SNSMessageHandler`**: Processes SNS topic notifications, uses `MessageId` for ordering
+
+Both handlers support the same features: message parsing, context creation, concurrency control, redaction, partial batch responses, and comprehensive error handling.
 
 ### `KinesisEventHandler`
 
@@ -248,9 +275,12 @@ event source, even when processing in parallel.
 In `DynamoStreamHandler`, events for the same _key_ will always be processed
 serially -- events from different keys will be processed in parallel.
 
-In `SQSMessageHandler`, events with the same `MessageGroupId` will always
-processed serially -- events with different `MessageGroupId` values will be
-processed in parallel.
+In `SQSMessageHandler` and `SNSMessageHandler`, ordering is maintained by:
+
+- **SQS**: Events with the same `MessageGroupId` are processed serially
+- **SNS**: Events are ordered by `MessageId` for consistency
+
+Events with different ordering keys are processed in parallel.
 
 In `KinesisEventHandler`, events with the same `partitionKey` will always
 processed serially -- events with different `partitionKey` values will be
@@ -279,9 +309,9 @@ const stream = new KinesisEventHandler({
   usePartialBatchResponses: true,
 });
 
-// SQS
-const stream = new SQSMessageHandler({
-  // ...
+// SQS & SNS (same configuration)
+const messageHandler = new SQSMessageHandler({
+  // ... or SNSMessageHandler
   usePartialBatchResponses: true,
 });
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './dynamo-streams';
-export * from './sqs';
 export * from './kinesis';
+export * from './sns';
+export * from './sqs';
 export { BaseContext } from './utils';

--- a/src/message-handler-base.ts
+++ b/src/message-handler-base.ts
@@ -1,0 +1,282 @@
+import { Context as AWSContext } from 'aws-lambda';
+import bunyan from 'bunyan';
+import { publicEncrypt } from 'crypto';
+import get from 'lodash/get';
+import { v4 as uuid } from 'uuid';
+import { LoggerInterface } from './logging';
+import {
+  BaseContext,
+  BaseHandlerConfig,
+  PartialBatchResponse,
+  handleUnprocessedRecords,
+  processWithOrdering,
+  withHealthCheckHandling,
+} from './utils';
+
+export interface MessageHandlerConfig<Message, Context>
+  extends BaseHandlerConfig<Context> {
+  /**
+   * A function for parsing messages into your custom type.
+   */
+  parseMessage: (body: string) => Message;
+
+  redactionConfig?: {
+    /**
+     * This will be called to redact the message body before logging it. By
+     * default, the full message body is logged.
+     */
+    redactMessageBody: (body: string) => string;
+
+    /**
+     * The public encryption key used for writing messages that contain
+     * sensitive information but failed to be redacted.
+     */
+    publicEncryptionKey: string;
+
+    /**
+     * Logged with the encrypted message to help identify the key used. For
+     * example, this could explain who has access to the key or how to get it.
+     */
+    publicKeyDescription: string;
+  };
+
+  /**
+   * Whether to ignore messages that fail to parse. If set to true,
+   * throwing in the custom parsing function will cause the message
+   * to be ignored, and never processed.
+   */
+  ignoreUnparseableMessages?: boolean;
+}
+
+export type MessageAction<Message, Context> = (
+  context: Context & BaseContext,
+  message: Message,
+) => void | Promise<void>;
+
+export interface MessageHandlerHarnessOptions<Message, Context> {
+  /**
+   * A function for stringifying messages.
+   */
+  stringifyMessage: (message: Message) => string;
+
+  /**
+   * An optional override for the logger.
+   */
+  logger?: LoggerInterface;
+
+  /**
+   * An optional override for creating the run context.
+   */
+  createRunContext?: () => Context | Promise<Context>;
+}
+
+export interface MessageHandlerHarnessContext<Message> {
+  /** Sends the specified event through the handler. */
+  sendEvent: (event: { messages: Message[] }) => Promise<PartialBatchResponse>;
+}
+
+export interface RecordExtractor<TRecord> {
+  extractMessage: (record: TRecord) => string;
+  extractMessageId: (record: TRecord) => string;
+  extractOrderingKey: (record: TRecord) => string;
+  redactRecord: (record: TRecord, redactedMessage: string) => TRecord;
+}
+
+export interface EventAdapter<TEvent, TRecord> {
+  extractRecords: (event: TEvent) => TRecord[];
+  createMockEvent: (records: TRecord[]) => TEvent;
+  createMockRecord: (messageBody: string, index: number) => TRecord;
+  getLogMessage: () => string;
+  getHandlerName: () => string;
+}
+
+const safeRedactor =
+  (
+    logger: LoggerInterface,
+    redactionConfig: NonNullable<
+      MessageHandlerConfig<any, any>['redactionConfig']
+    >,
+  ) =>
+  (body: string) => {
+    try {
+      return redactionConfig.redactMessageBody(body);
+    } catch (error) {
+      let encryptedBody;
+
+      // If redaction fails, then encrypt the message body and log it.
+      // Encryption allows for developers to decrypt the message if needed
+      // but does not log sensitive information to the log stream.
+      try {
+        encryptedBody = publicEncrypt(
+          redactionConfig.publicEncryptionKey,
+          Buffer.from(body),
+        ).toString('base64');
+      } catch (error) {
+        // If encryption fails, then log the encryption error and replace
+        // the body with dummy text.
+        logger.error({ error }, 'Failed to encrypt message body');
+        encryptedBody = '[ENCRYPTION FAILED]';
+      }
+
+      // Log the redaction error
+      logger.error(
+        {
+          error,
+          encryptedBody,
+          publicKeyDescription: redactionConfig.publicKeyDescription,
+        },
+        'Failed to redact message body',
+      );
+      return '[REDACTION FAILED]';
+    }
+  };
+
+/**
+ * Base class for message handlers that provides common functionality.
+ */
+export abstract class MessageHandlerBase<TEvent, TRecord, TMessage, TContext> {
+  protected messageActions: MessageAction<TMessage, TContext>[] = [];
+
+  constructor(
+    readonly config: MessageHandlerConfig<TMessage, TContext>,
+    protected recordExtractor: RecordExtractor<TRecord>,
+    protected eventAdapter: EventAdapter<TEvent, TRecord>,
+  ) {}
+
+  protected addAction(action: MessageAction<TMessage, TContext>): void {
+    this.messageActions.push(action);
+  }
+
+  lambda(): (
+    event: TEvent,
+    context: AWSContext,
+  ) => Promise<PartialBatchResponse> {
+    return withHealthCheckHandling(async (event, awsContext) => {
+      // 1. Setup the logger.
+      // The batch ID provides a way to correlate all messages that are processed together.
+      // This is particularly useful for correlating handled and unhandled records.
+      const batchId = uuid();
+
+      /* istanbul ignore next */
+      const logger =
+        this.config.logger ??
+        bunyan.createLogger({
+          batchId,
+          name: this.eventAdapter.getHandlerName(),
+          requestId: awsContext.awsRequestId,
+        });
+
+      // 2. Process all the records.
+      const records = this.eventAdapter.extractRecords(event);
+      const redactor = this.config.redactionConfig
+        ? safeRedactor(logger, this.config.redactionConfig)
+        : undefined;
+
+      const redactRecord = (record: TRecord): TRecord =>
+        redactor
+          ? this.recordExtractor.redactRecord(
+              record,
+              redactor(this.recordExtractor.extractMessage(record)),
+            )
+          : record;
+
+      const redactedEvent = redactor
+        ? this.eventAdapter.createMockEvent(records.map(redactRecord))
+        : event;
+
+      logger.info({ event: redactedEvent }, this.eventAdapter.getLogMessage());
+
+      const { unprocessedRecords } = await processWithOrdering(
+        {
+          items: records,
+          orderBy: (record: TRecord) =>
+            this.recordExtractor.extractOrderingKey(record),
+          concurrency: this.config.concurrency ?? 5,
+        },
+        async (record) => {
+          const messageLogger = logger.child({
+            messageId: this.recordExtractor.extractMessageId(record),
+          });
+
+          let parsedMessage: TMessage;
+          try {
+            parsedMessage = this.config.parseMessage(
+              this.recordExtractor.extractMessage(record),
+            );
+          } catch (err) {
+            messageLogger.error({ err }, 'Failed to parse message');
+            if (this.config.ignoreUnparseableMessages) {
+              messageLogger.warn(
+                'ignoreUnparseableMessages is set to true. Ignoring message.',
+              );
+              return;
+            }
+            throw err;
+          }
+
+          // Extracting the correlation ID from the message allows for
+          // multiple messages to be correlated together.
+          const correlationId = get(parsedMessage, 'correlationId', uuid());
+
+          // Context is built per message to support message-specific correlation IDs.
+          const context: BaseContext & TContext = {
+            correlationId,
+            logger: messageLogger.child({ correlationId }),
+          } as any;
+
+          Object.assign(context, await this.config.createRunContext(context));
+
+          for (const action of this.messageActions) {
+            await action({ ...context }, parsedMessage);
+          }
+
+          context.logger.info(
+            `Successfully processed ${this.eventAdapter
+              .getHandlerName()
+              .replace('Handler', '')
+              .toLowerCase()} message`,
+          );
+        },
+      );
+
+      return handleUnprocessedRecords({
+        logger, // The base logger only logs the batch ID.
+        unprocessedRecords,
+        usePartialBatchResponses: !!this.config.usePartialBatchResponses,
+        getItemIdentifier: (record) =>
+          this.recordExtractor.extractMessageId(record),
+        redactRecord,
+      });
+    });
+  }
+
+  harness(
+    options: MessageHandlerHarnessOptions<TMessage, TContext>,
+    HandlerClass: new (config: MessageHandlerConfig<TMessage, TContext>) => any,
+  ): MessageHandlerHarnessContext<TMessage> {
+    const { stringifyMessage, ...overrides } = options;
+
+    // Make a copy of the handler.
+    const handler = new HandlerClass({ ...this.config, ...overrides });
+    for (const action of this.messageActions) {
+      handler.onMessage(action);
+    }
+    const lambda = handler.lambda();
+
+    return {
+      sendEvent: ({ messages }) => {
+        const records = messages.map((msg, index) =>
+          this.eventAdapter.createMockRecord(stringifyMessage(msg), index),
+        );
+        const event = this.eventAdapter.createMockEvent(records);
+
+        return lambda(
+          event,
+          // We don't need to mock every field on the context -- there are lots.
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          { awsRequestId: uuid() } as any,
+        );
+      },
+    };
+  }
+}

--- a/src/sns.test.ts
+++ b/src/sns.test.ts
@@ -1,0 +1,1071 @@
+import { privateDecrypt } from 'crypto';
+import { promises as fs } from 'fs';
+import { v4 as uuid } from 'uuid';
+
+import { useMockLogger } from './jest-utils';
+import { SNSMessageAction, SNSMessageHandler } from './sns';
+
+const logger = useMockLogger();
+
+let publicKey: string;
+beforeAll(async () => {
+  publicKey = await fs.readFile(
+    __dirname + '/__fixtures__/public-key.pem',
+    'utf8',
+  );
+});
+
+const testSerializer = {
+  parseMessage: (msg: string) => JSON.parse(msg),
+  stringifyMessage: (msg: any) => JSON.stringify(msg),
+};
+
+describe('SNSMessageHandler', () => {
+  test('responds to HTTP health checks', async () => {
+    const lambda = new SNSMessageHandler({
+      logger,
+      parseMessage: testSerializer.parseMessage,
+      createRunContext: () => ({}),
+    }).lambda();
+
+    const result = await lambda({ httpMethod: 'GET' } as any, {} as any);
+
+    expect(result).toStrictEqual({
+      statusCode: 200,
+      body: '{"healthy":true}',
+    });
+  });
+
+  test('responds to healthCheck events', async () => {
+    const lambda = new SNSMessageHandler({
+      logger,
+      parseMessage: testSerializer.parseMessage,
+      createRunContext: () => ({}),
+    }).lambda();
+
+    const result = await lambda({ healthCheck: true } as any, {} as any);
+
+    expect(result).toStrictEqual({
+      healthy: true,
+    });
+  });
+
+  test('generates a correlation id', async () => {
+    expect.assertions(3);
+
+    const lambda = new SNSMessageHandler({
+      logger,
+      parseMessage: testSerializer.parseMessage,
+      createRunContext: (ctx) => {
+        expect(typeof ctx.correlationId === 'string').toBe(true);
+        return {};
+      },
+    }).lambda();
+
+    const response = await lambda(
+      {
+        Records: [
+          {
+            EventVersion: '1.0',
+            EventSubscriptionArn: 'test-subscription',
+            EventSource: 'aws:sns',
+            Sns: {
+              SignatureVersion: '1',
+              Timestamp: '2023-01-01T00:00:00.000Z',
+              Signature: 'test-signature',
+              SigningCertUrl: 'test-cert-url',
+              MessageId: 'test-message-id',
+              Message: JSON.stringify({ data: 'test-event-1' }),
+              MessageAttributes: {},
+              Type: 'Notification',
+              UnsubscribeUrl: 'test-unsubscribe-url',
+              TopicArn: 'test-topic-arn',
+              Subject: null,
+            },
+          },
+        ],
+      } as any,
+      {} as any,
+    );
+
+    // Assert that when all messages are processed successfully and partial
+    // batch responses are not used (the default setting), nothing is returned
+    // as the lambda response.
+    expect(response).toBeUndefined();
+    expect(logger.child).toHaveBeenCalledWith(
+      expect.objectContaining({ correlationId: expect.any(String) }),
+    );
+  });
+
+  test('accepts a correlation id', async () => {
+    expect.assertions(3);
+
+    const lambda = new SNSMessageHandler({
+      logger,
+      parseMessage: testSerializer.parseMessage,
+      createRunContext: (ctx) => {
+        expect(typeof ctx.correlationId === 'string').toBe(true);
+        return {};
+      },
+    }).lambda();
+
+    const correlationId = uuid();
+    const response = await lambda(
+      {
+        Records: [
+          {
+            EventVersion: '1.0',
+            EventSubscriptionArn: 'test-subscription',
+            EventSource: 'aws:sns',
+            Sns: {
+              SignatureVersion: '1',
+              Timestamp: '2023-01-01T00:00:00.000Z',
+              Signature: 'test-signature',
+              SigningCertUrl: 'test-cert-url',
+              MessageId: 'test-message-id',
+              Message: JSON.stringify({ correlationId, data: 'test-event-1' }),
+              MessageAttributes: {},
+              Type: 'Notification',
+              UnsubscribeUrl: 'test-unsubscribe-url',
+              TopicArn: 'test-topic-arn',
+              Subject: null,
+            },
+          },
+        ],
+      } as any,
+      {} as any,
+    );
+
+    // Assert that when all messages are processed successfully and partial
+    // batch responses are not used (the default setting), nothing is returned
+    // as the lambda response.
+    expect(response).toBeUndefined();
+    expect(logger.child).toHaveBeenCalledWith(
+      expect.objectContaining({ correlationId }),
+    );
+  });
+
+  test('allows body redaction', async () => {
+    expect.assertions(2);
+
+    const lambda = new SNSMessageHandler({
+      logger,
+      redactionConfig: {
+        redactMessageBody: () => 'REDACTED',
+        publicEncryptionKey: publicKey,
+        publicKeyDescription: 'test-public-key',
+      },
+      parseMessage: testSerializer.parseMessage,
+      createRunContext: (ctx) => {
+        expect(typeof ctx.correlationId === 'string').toBe(true);
+        return {};
+      },
+    }).lambda();
+
+    await lambda(
+      {
+        Records: [
+          {
+            EventVersion: '1.0',
+            EventSubscriptionArn: 'test-subscription',
+            EventSource: 'aws:sns',
+            Sns: {
+              SignatureVersion: '1',
+              Timestamp: '2023-01-01T00:00:00.000Z',
+              Signature: 'test-signature',
+              SigningCertUrl: 'test-cert-url',
+              MessageId: 'test-message-id',
+              Message: JSON.stringify({ data: 'test-event-1' }),
+              MessageAttributes: {},
+              Type: 'Notification',
+              UnsubscribeUrl: 'test-unsubscribe-url',
+              TopicArn: 'test-topic-arn',
+              Subject: null,
+            },
+          },
+        ],
+      } as any,
+      {} as any,
+    );
+
+    // Assert that the message body was redacted.
+    expect(logger.info).toHaveBeenCalledWith(
+      {
+        event: {
+          Records: [
+            {
+              EventVersion: '1.0',
+              EventSubscriptionArn: 'test-subscription',
+              EventSource: 'aws:sns',
+              Sns: {
+                SignatureVersion: '1',
+                Timestamp: '2023-01-01T00:00:00.000Z',
+                Signature: 'test-signature',
+                SigningCertUrl: 'test-cert-url',
+                MessageId: 'test-message-id',
+                Message: 'REDACTED',
+                MessageAttributes: {},
+                Type: 'Notification',
+                UnsubscribeUrl: 'test-unsubscribe-url',
+                TopicArn: 'test-topic-arn',
+                Subject: null,
+              },
+            },
+          ],
+        },
+      },
+      'Processing SNS topic message',
+    );
+  });
+
+  test('if redaction fails, a redacted body is logged with an encrypted body', async () => {
+    expect.assertions(5);
+
+    const error = new Error('Failed to redact message');
+    const lambda = new SNSMessageHandler({
+      logger,
+      redactionConfig: {
+        redactMessageBody: () => {
+          throw error;
+        },
+        publicEncryptionKey: publicKey,
+        publicKeyDescription: 'test-public-key',
+      },
+      parseMessage: testSerializer.parseMessage,
+      createRunContext: (ctx) => {
+        expect(typeof ctx.correlationId === 'string').toBe(true);
+        return {};
+      },
+    }).lambda();
+
+    const messageBody = JSON.stringify({ data: 'test-event-1' });
+    const event = {
+      Records: [
+        {
+          EventVersion: '1.0',
+          EventSubscriptionArn: 'test-subscription',
+          EventSource: 'aws:sns',
+          Sns: {
+            SignatureVersion: '1',
+            Timestamp: '2023-01-01T00:00:00.000Z',
+            Signature: 'test-signature',
+            SigningCertUrl: 'test-cert-url',
+            MessageId: 'test-message-id',
+            Message: messageBody,
+            MessageAttributes: {},
+            Type: 'Notification',
+            UnsubscribeUrl: 'test-unsubscribe-url',
+            TopicArn: 'test-topic-arn',
+            Subject: null,
+          },
+        },
+      ],
+    } as any;
+    const response = await lambda(event, {} as any);
+
+    // Expect no failure
+    expect(response).toBeUndefined();
+
+    // Assert that the message body was shown redacted. Along with the
+    // redacted body, an encrypted body is also logged with the redaction
+    // error to help debugging.
+    expect(logger.error).toHaveBeenCalledWith(
+      {
+        error,
+        encryptedBody: expect.any(String),
+        publicKeyDescription: 'test-public-key',
+      },
+      'Failed to redact message body',
+    );
+
+    // Verify that the encrypted body can be decrypted.
+    const privateKey = await fs.readFile(
+      __dirname + '/__fixtures__/private-key.pem',
+      'utf8',
+    );
+    const encryptedBody = logger.error.mock.calls[0][0].encryptedBody;
+    const decrypted = privateDecrypt(
+      privateKey,
+      Buffer.from(encryptedBody, 'base64'),
+    ).toString('utf8');
+    expect(decrypted).toEqual(messageBody);
+
+    // Verify the the body was redacted.
+    expect(logger.info).toHaveBeenCalledWith(
+      {
+        event: {
+          ...event,
+          Records: event.Records.map((record: any) => ({
+            ...record,
+            Sns: {
+              ...record.Sns,
+              Message: '[REDACTION FAILED]',
+            },
+          })),
+        },
+      },
+      'Processing SNS topic message',
+    );
+  });
+
+  test('if redaction fails, and encryption fails, a redacted body is logged with the encryption failure', async () => {
+    expect.assertions(5);
+
+    const error = new Error('Failed to redact message');
+    const lambda = new SNSMessageHandler({
+      logger,
+      redactionConfig: {
+        redactMessageBody: () => {
+          throw error;
+        },
+        publicEncryptionKey: 'not-a-valid-key',
+        publicKeyDescription: 'test-public-key',
+      },
+      parseMessage: testSerializer.parseMessage,
+      createRunContext: (ctx) => {
+        expect(typeof ctx.correlationId === 'string').toBe(true);
+        return {};
+      },
+    }).lambda();
+
+    const messageBody = JSON.stringify({ data: 'test-event-1' });
+    const event = {
+      Records: [
+        {
+          EventVersion: '1.0',
+          EventSubscriptionArn: 'test-subscription',
+          EventSource: 'aws:sns',
+          Sns: {
+            SignatureVersion: '1',
+            Timestamp: '2023-01-01T00:00:00.000Z',
+            Signature: 'test-signature',
+            SigningCertUrl: 'test-cert-url',
+            MessageId: 'test-message-id',
+            Message: messageBody,
+            MessageAttributes: {},
+            Type: 'Notification',
+            UnsubscribeUrl: 'test-unsubscribe-url',
+            TopicArn: 'test-topic-arn',
+            Subject: null,
+          },
+        },
+      ],
+    } as any;
+    const response = await lambda(event, {} as any);
+
+    // Expect no failure
+    expect(response).toBeUndefined();
+
+    // Assert that the message body was shown redacted. Along with the
+    // redacted body, an encrypted body is also logged with the redaction
+    // error to help debugging.
+    expect(logger.error).toHaveBeenCalledWith(
+      {
+        error,
+        encryptedBody: '[ENCRYPTION FAILED]', // Signals that encryption failed
+        publicKeyDescription: 'test-public-key',
+      },
+      'Failed to redact message body',
+    );
+
+    // When encryption fails, the failure is logged.
+    expect(logger.error).toHaveBeenCalledWith(
+      {
+        error: expect.anything(),
+      },
+      'Failed to encrypt message body',
+    );
+
+    // Verify the the body was redacted.
+    expect(logger.info).toHaveBeenCalledWith(
+      {
+        event: {
+          ...event,
+          Records: event.Records.map((record: any) => ({
+            ...record,
+            Sns: {
+              ...record.Sns,
+              Message: '[REDACTION FAILED]',
+            },
+          })),
+        },
+      },
+      'Processing SNS topic message',
+    );
+  });
+
+  describe('error handling', () => {
+    const records = [
+      {
+        EventVersion: '1.0',
+        EventSubscriptionArn: 'test-subscription',
+        EventSource: 'aws:sns',
+        Sns: {
+          SignatureVersion: '1',
+          Timestamp: '2023-01-01T00:00:00.000Z',
+          Signature: 'test-signature',
+          SigningCertUrl: 'test-cert-url',
+          MessageId: 'message-1',
+          Message: JSON.stringify({ name: 'test-event-1' }),
+          MessageAttributes: {},
+          Type: 'Notification',
+          UnsubscribeUrl: 'test-unsubscribe-url',
+          TopicArn: 'test-topic-arn',
+          Subject: null,
+        },
+      },
+      {
+        EventVersion: '1.0',
+        EventSubscriptionArn: 'test-subscription',
+        EventSource: 'aws:sns',
+        Sns: {
+          SignatureVersion: '1',
+          Timestamp: '2023-01-01T00:00:00.000Z',
+          Signature: 'test-signature',
+          SigningCertUrl: 'test-cert-url',
+          MessageId: 'message-2',
+          Message: JSON.stringify({ name: 'test-event-2' }),
+          MessageAttributes: {},
+          Type: 'Notification',
+          UnsubscribeUrl: 'test-unsubscribe-url',
+          TopicArn: 'test-topic-arn',
+          Subject: null,
+        },
+      },
+      {
+        EventVersion: '1.0',
+        EventSubscriptionArn: 'test-subscription',
+        EventSource: 'aws:sns',
+        Sns: {
+          SignatureVersion: '1',
+          Timestamp: '2023-01-01T00:00:00.000Z',
+          Signature: 'test-signature',
+          SigningCertUrl: 'test-cert-url',
+          MessageId: 'message-3',
+          Message: JSON.stringify({ name: 'test-event-3' }),
+          MessageAttributes: {},
+          Type: 'Notification',
+          UnsubscribeUrl: 'test-unsubscribe-url',
+          TopicArn: 'test-topic-arn',
+          Subject: null,
+        },
+      },
+      {
+        EventVersion: '1.0',
+        EventSubscriptionArn: 'test-subscription',
+        EventSource: 'aws:sns',
+        Sns: {
+          SignatureVersion: '1',
+          Timestamp: '2023-01-01T00:00:00.000Z',
+          Signature: 'test-signature',
+          SigningCertUrl: 'test-cert-url',
+          MessageId: 'message-4',
+          Message: JSON.stringify({ name: 'test-event-4' }),
+          MessageAttributes: {},
+          Type: 'Notification',
+          UnsubscribeUrl: 'test-unsubscribe-url',
+          TopicArn: 'test-topic-arn',
+          Subject: null,
+        },
+      },
+    ];
+
+    const errorMessageHandler: SNSMessageAction<{ name: string }, any> = (
+      ctx,
+      message,
+    ) => {
+      // Fail on the third message
+      if (message.name === 'test-event-3') {
+        throw new Error(`Failed to process message ${message.name}`);
+      }
+    };
+
+    const successMessageHandler: SNSMessageAction<
+      { name: string },
+      any
+    > = () => {
+      return Promise.resolve();
+    };
+
+    test('throws on unprocessed events by default', async () => {
+      expect.assertions(1);
+      const handler = new SNSMessageHandler({
+        logger,
+        parseMessage: testSerializer.parseMessage,
+        createRunContext: () => ({}),
+        concurrency: 2,
+      })
+        .onMessage(errorMessageHandler)
+        .lambda();
+
+      try {
+        await handler(
+          {
+            Records: records,
+          } as any,
+          {} as any,
+        );
+      } catch (e: any) {
+        expect(e.message).toContain(
+          'Error: Failed to process message test-event-3',
+        );
+      }
+    });
+
+    test('returns partial batch response when setting is enabled', async () => {
+      const handler = new SNSMessageHandler({
+        logger,
+        parseMessage: testSerializer.parseMessage,
+        createRunContext: () => ({}),
+        usePartialBatchResponses: true,
+        concurrency: 2,
+      })
+        .onMessage(errorMessageHandler)
+        .lambda();
+
+      const result = await handler(
+        {
+          Records: records,
+        } as any,
+        {} as any,
+      );
+
+      // Expect that the bodies have not been redacted
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          itemIdentifier: 'message-3',
+          failedRecord: expect.objectContaining({
+            Sns: expect.objectContaining({
+              Message: JSON.stringify({
+                name: `test-event-3`,
+              }),
+            }),
+          }),
+          err: expect.objectContaining({
+            message: 'Failed to process message test-event-3',
+          }),
+        }),
+        'Failed to process record',
+      );
+
+      const batchItemFailures = [{ itemIdentifier: 'message-3' }];
+
+      expect(result).toEqual({
+        batchItemFailures,
+      });
+      expect(logger.info).not.toHaveBeenCalledWith(
+        'Successfully processed all messages',
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        {
+          batchItemFailures,
+        },
+        'Completing with partial batch response',
+      );
+    });
+
+    test('returns nothing when all events are processed successfully', async () => {
+      const handler = new SNSMessageHandler({
+        logger,
+        parseMessage: testSerializer.parseMessage,
+        createRunContext: () => ({}),
+        usePartialBatchResponses: true,
+        concurrency: 2,
+      })
+        .onMessage(successMessageHandler)
+        .lambda();
+
+      const result = await handler(
+        {
+          Records: records,
+        } as any,
+        {} as any,
+      );
+
+      expect(result).toEqual(undefined);
+      expect(logger.error).not.toHaveBeenCalledWith(
+        expect.any(Object),
+        'Failed to fully process message group',
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        'Successfully processed all records',
+      );
+    });
+
+    test('redacts bodies of partial failures when redaction is enabled', async () => {
+      const handler = new SNSMessageHandler({
+        logger,
+        parseMessage: testSerializer.parseMessage,
+        redactionConfig: {
+          redactMessageBody: () => 'REDACTED',
+          publicEncryptionKey: publicKey,
+          publicKeyDescription: 'test-public-key',
+        },
+        createRunContext: () => ({}),
+        usePartialBatchResponses: true,
+        concurrency: 2,
+      })
+        .onMessage(errorMessageHandler)
+        .lambda();
+
+      await handler(
+        {
+          Records: records,
+        } as any,
+        {} as any,
+      );
+
+      // Expect that the bodies have been redacted
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          itemIdentifier: 'message-3',
+          failedRecord: expect.objectContaining({
+            Sns: expect.objectContaining({
+              Message: 'REDACTED',
+              MessageId: 'message-3',
+            }),
+          }),
+          err: expect.objectContaining({
+            message: 'Failed to process message test-event-3',
+          }),
+        }),
+        'Failed to process record',
+      );
+    });
+  });
+
+  test('sending messages with context', async () => {
+    const dataSources = {
+      doSomething: jest.fn(),
+    };
+
+    const lambda = new SNSMessageHandler({
+      logger,
+      parseMessage: testSerializer.parseMessage,
+      createRunContext: () => dataSources,
+      concurrency: 1,
+    })
+      .onMessage((ctx, message) => {
+        ctx.doSomething('first-handler', message);
+      })
+      .onMessage((ctx, message) => {
+        ctx.doSomething('second-handler', message);
+      })
+      .lambda();
+
+    await lambda(
+      {
+        Records: [
+          {
+            EventVersion: '1.0',
+            EventSubscriptionArn: 'test-subscription',
+            EventSource: 'aws:sns',
+            Sns: {
+              SignatureVersion: '1',
+              Timestamp: '2023-01-01T00:00:00.000Z',
+              Signature: 'test-signature',
+              SigningCertUrl: 'test-cert-url',
+              MessageId: 'message-1',
+              Message: JSON.stringify({ data: 'test-event-1' }),
+              MessageAttributes: {},
+              Type: 'Notification',
+              UnsubscribeUrl: 'test-unsubscribe-url',
+              TopicArn: 'test-topic-arn',
+              Subject: null,
+            },
+          },
+          {
+            EventVersion: '1.0',
+            EventSubscriptionArn: 'test-subscription',
+            EventSource: 'aws:sns',
+            Sns: {
+              SignatureVersion: '1',
+              Timestamp: '2023-01-01T00:00:00.000Z',
+              Signature: 'test-signature',
+              SigningCertUrl: 'test-cert-url',
+              MessageId: 'message-2',
+              Message: JSON.stringify({ data: 'test-event-2' }),
+              MessageAttributes: {},
+              Type: 'Notification',
+              UnsubscribeUrl: 'test-unsubscribe-url',
+              TopicArn: 'test-topic-arn',
+              Subject: null,
+            },
+          },
+        ],
+      } as any,
+      {} as any,
+    );
+
+    // Expect 4 calls. 2 message handlers * 2 events.
+    expect(dataSources.doSomething).toHaveBeenCalledTimes(4);
+
+    // Now, confirm the ordering.
+    expect(dataSources.doSomething).toHaveBeenNthCalledWith(
+      1,
+      'first-handler',
+      {
+        data: 'test-event-1',
+      },
+    );
+    expect(dataSources.doSomething).toHaveBeenNthCalledWith(
+      2,
+      'second-handler',
+      {
+        data: 'test-event-1',
+      },
+    );
+    expect(dataSources.doSomething).toHaveBeenNthCalledWith(
+      3,
+      'first-handler',
+      {
+        data: 'test-event-2',
+      },
+    );
+    expect(dataSources.doSomething).toHaveBeenNthCalledWith(
+      4,
+      'second-handler',
+      {
+        data: 'test-event-2',
+      },
+    );
+  });
+
+  describe('harness', () => {
+    test('sends events correctly', async () => {
+      const dataSources = {
+        doSomething: jest.fn(),
+      };
+
+      const { sendEvent } = new SNSMessageHandler({
+        logger,
+        parseMessage: testSerializer.parseMessage,
+        createRunContext: () => dataSources,
+      })
+        .onMessage((ctx, msg) => {
+          ctx.doSomething(msg);
+        })
+        .harness({
+          stringifyMessage: testSerializer.stringifyMessage,
+        });
+
+      await sendEvent({
+        messages: [{ data: 'test-event-1' }, { data: 'test-event-2' }],
+      });
+
+      expect(dataSources.doSomething).toHaveBeenCalledTimes(2);
+      expect(dataSources.doSomething).toHaveBeenNthCalledWith(1, {
+        data: 'test-event-1',
+      });
+      expect(dataSources.doSomething).toHaveBeenNthCalledWith(2, {
+        data: 'test-event-2',
+      });
+    });
+
+    test('allows overriding context and logger', async () => {
+      const testValue = uuid();
+
+      const overrideLogger = {
+        info: jest.fn(),
+        error: jest.fn(),
+        child: jest.fn(),
+      };
+      overrideLogger.child.mockImplementation(() => overrideLogger);
+
+      const dataSources = {
+        doSomething: jest.fn(),
+      };
+
+      const { sendEvent } = new SNSMessageHandler({
+        logger,
+        parseMessage: testSerializer.parseMessage,
+        createRunContext: () => ({ dataSources }),
+      })
+        .onMessage((ctx) => {
+          ctx.logger.info((ctx as any).testValue);
+          ctx.dataSources.doSomething((ctx as any).testValue);
+        })
+        .harness({
+          stringifyMessage: testSerializer.stringifyMessage,
+          logger: overrideLogger as any,
+          createRunContext: () => ({ dataSources, testValue }),
+        });
+
+      await sendEvent({ messages: [{}] });
+
+      expect(logger.info).not.toHaveBeenCalled();
+      expect(overrideLogger.info).toHaveBeenCalledWith(testValue);
+
+      expect(dataSources.doSomething).toHaveBeenCalledWith(testValue);
+    });
+  });
+
+  const wait = (ms: number) =>
+    new Promise((resolve) => setTimeout(resolve, ms));
+
+  describe('parallelization', () => {
+    test('processes events in parallel', async () => {
+      const handler = new SNSMessageHandler({
+        logger,
+        parseMessage: testSerializer.parseMessage,
+        createRunContext: () => ({}),
+      })
+        .onMessage(async () => {
+          // We'll wait 100ms per event, then use that to make timing
+          // assertions below.
+          await wait(100);
+        })
+        .lambda();
+
+      const start = Date.now();
+
+      await handler(
+        {
+          Records: [
+            {
+              EventVersion: '1.0',
+              EventSubscriptionArn: 'test-subscription',
+              EventSource: 'aws:sns',
+              Sns: {
+                SignatureVersion: '1',
+                Timestamp: '2023-01-01T00:00:00.000Z',
+                Signature: 'test-signature',
+                SigningCertUrl: 'test-cert-url',
+                MessageId: 'message-1',
+                Message: JSON.stringify({ data: 'test-event-1' }),
+                MessageAttributes: {},
+                Type: 'Notification',
+                UnsubscribeUrl: 'test-unsubscribe-url',
+                TopicArn: 'test-topic-arn',
+                Subject: null,
+              },
+            },
+            {
+              EventVersion: '1.0',
+              EventSubscriptionArn: 'test-subscription',
+              EventSource: 'aws:sns',
+              Sns: {
+                SignatureVersion: '1',
+                Timestamp: '2023-01-01T00:00:00.000Z',
+                Signature: 'test-signature',
+                SigningCertUrl: 'test-cert-url',
+                MessageId: 'message-2',
+                Message: JSON.stringify({ data: 'test-event-2' }),
+                MessageAttributes: {},
+                Type: 'Notification',
+                UnsubscribeUrl: 'test-unsubscribe-url',
+                TopicArn: 'test-topic-arn',
+                Subject: null,
+              },
+            },
+            {
+              EventVersion: '1.0',
+              EventSubscriptionArn: 'test-subscription',
+              EventSource: 'aws:sns',
+              Sns: {
+                SignatureVersion: '1',
+                Timestamp: '2023-01-01T00:00:00.000Z',
+                Signature: 'test-signature',
+                SigningCertUrl: 'test-cert-url',
+                MessageId: 'message-3',
+                Message: JSON.stringify({ data: 'test-event-3' }),
+                MessageAttributes: {},
+                Type: 'Notification',
+                UnsubscribeUrl: 'test-unsubscribe-url',
+                TopicArn: 'test-topic-arn',
+                Subject: null,
+              },
+            },
+          ] as any,
+        },
+        {} as any,
+      );
+
+      const end = Date.now();
+
+      // This assertion confirms there is parallel processing.
+      expect(end - start).toBeLessThan(200);
+    });
+  });
+
+  test('throws when encountering an unparseable message', async () => {
+    const lambda = new SNSMessageHandler({
+      logger,
+      parseMessage: testSerializer.parseMessage,
+      createRunContext: () => ({}),
+    }).lambda();
+
+    await expect(
+      lambda(
+        {
+          Records: [
+            {
+              EventVersion: '1.0',
+              EventSubscriptionArn: 'test-subscription',
+              EventSource: 'aws:sns',
+              Sns: {
+                SignatureVersion: '1',
+                Timestamp: '2023-01-01T00:00:00.000Z',
+                Signature: 'test-signature',
+                SigningCertUrl: 'test-cert-url',
+                MessageId: 'message-1',
+                Message: 'not-a-json-string',
+                MessageAttributes: {},
+                Type: 'Notification',
+                UnsubscribeUrl: 'test-unsubscribe-url',
+                TopicArn: 'test-topic-arn',
+                Subject: null,
+              },
+            },
+          ],
+        } as any,
+        {} as any,
+      ),
+    ).rejects.toThrow(/Unexpected token/);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        err: expect.objectContaining({
+          message: expect.stringContaining('Unexpected token'),
+        }),
+      }),
+      'Failed to parse message',
+    );
+  });
+
+  test('respects ignoreUnparseableMessages', async () => {
+    const processor = jest.fn().mockResolvedValue(void 0);
+    const lambda = new SNSMessageHandler({
+      logger,
+      parseMessage: testSerializer.parseMessage,
+      createRunContext: () => ({}),
+      ignoreUnparseableMessages: true,
+    })
+      .onMessage((ctx, message) => processor(message))
+      .lambda();
+
+    await lambda(
+      {
+        Records: [
+          {
+            EventVersion: '1.0',
+            EventSubscriptionArn: 'test-subscription',
+            EventSource: 'aws:sns',
+            Sns: {
+              SignatureVersion: '1',
+              Timestamp: '2023-01-01T00:00:00.000Z',
+              Signature: 'test-signature',
+              SigningCertUrl: 'test-cert-url',
+              MessageId: 'message-1',
+              Message: 'not-a-json-string',
+              MessageAttributes: {},
+              Type: 'Notification',
+              UnsubscribeUrl: 'test-unsubscribe-url',
+              TopicArn: 'test-topic-arn',
+              Subject: null,
+            },
+          },
+          {
+            EventVersion: '1.0',
+            EventSubscriptionArn: 'test-subscription',
+            EventSource: 'aws:sns',
+            Sns: {
+              SignatureVersion: '1',
+              Timestamp: '2023-01-01T00:00:00.000Z',
+              Signature: 'test-signature',
+              SigningCertUrl: 'test-cert-url',
+              MessageId: 'message-2',
+              Message: JSON.stringify({ message: 'test-message' }),
+              MessageAttributes: {},
+              Type: 'Notification',
+              UnsubscribeUrl: 'test-unsubscribe-url',
+              TopicArn: 'test-topic-arn',
+              Subject: null,
+            },
+          },
+        ],
+      } as any,
+      {} as any,
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        err: expect.objectContaining({
+          message: expect.stringContaining('Unexpected token'),
+        }),
+      }),
+      'Failed to parse message',
+    );
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'ignoreUnparseableMessages is set to true. Ignoring message.',
+    );
+
+    expect(processor).toHaveBeenCalledTimes(1);
+    expect(processor).toHaveBeenCalledWith({ message: 'test-message' });
+  });
+
+  test('handles missing MessageId gracefully', async () => {
+    const processor = jest.fn();
+
+    const lambda = new SNSMessageHandler({
+      logger,
+      parseMessage: testSerializer.parseMessage,
+      createRunContext: () => ({}),
+    })
+      .onMessage((ctx, message) => {
+        processor(message);
+      })
+      .lambda();
+
+    const response = await lambda(
+      {
+        Records: [
+          {
+            EventVersion: '1.0',
+            EventSubscriptionArn: 'test-subscription',
+            EventSource: 'aws:sns',
+            Sns: {
+              SignatureVersion: '1',
+              Timestamp: '2023-01-01T00:00:00.000Z',
+              Signature: 'test-signature',
+              SigningCertUrl: 'test-cert-url',
+              MessageId: null, // This tests the ?? '' fallback
+              Message: JSON.stringify({ message: 'test-message' }),
+              MessageAttributes: {},
+              Type: 'Notification',
+              UnsubscribeUrl: 'test-unsubscribe-url',
+              TopicArn: 'test-topic-arn',
+              Subject: null,
+            },
+          },
+          {
+            EventVersion: '1.0',
+            EventSubscriptionArn: 'test-subscription',
+            EventSource: 'aws:sns',
+            Sns: {
+              SignatureVersion: '1',
+              Timestamp: '2023-01-01T00:00:00.000Z',
+              Signature: 'test-signature',
+              SigningCertUrl: 'test-cert-url',
+              MessageId: undefined, // This tests the ?? uuid() fallback in ordering
+              Message: JSON.stringify({ message: 'test-message-2' }),
+              MessageAttributes: {},
+              Type: 'Notification',
+              UnsubscribeUrl: 'test-unsubscribe-url',
+              TopicArn: 'test-topic-arn',
+              Subject: null,
+            },
+          },
+        ],
+      } as any,
+      {} as any,
+    );
+
+    expect(response).toBeUndefined();
+
+    expect(processor).toHaveBeenCalledTimes(2);
+    expect(processor).toHaveBeenCalledWith({ message: 'test-message' });
+    expect(processor).toHaveBeenCalledWith({ message: 'test-message-2' });
+  });
+});

--- a/src/sns.ts
+++ b/src/sns.ts
@@ -1,0 +1,98 @@
+import { SNSEvent, SNSEventRecord } from 'aws-lambda';
+import { v4 as uuid } from 'uuid';
+import {
+  EventAdapter,
+  MessageAction,
+  MessageHandlerBase,
+  MessageHandlerConfig,
+  MessageHandlerHarnessContext,
+  MessageHandlerHarnessOptions,
+  RecordExtractor,
+} from './message-handler-base';
+
+export type SNSMessageHandlerConfig<Message, Context> = MessageHandlerConfig<
+  Message,
+  Context
+>;
+
+export type SNSMessageAction<Message, Context> = MessageAction<
+  Message,
+  Context
+>;
+
+export type SNSMessageHandlerHarnessOptions<Message, Context> =
+  MessageHandlerHarnessOptions<Message, Context>;
+
+export type SNSMessageHandlerHarnessContext<Message> =
+  MessageHandlerHarnessContext<Message>;
+
+const SNS_RECORD_EXTRACTOR: RecordExtractor<SNSEventRecord> = {
+  extractMessage: (record) => record.Sns.Message,
+  extractMessageId: (record) => record.Sns.MessageId ?? '',
+  extractOrderingKey: (record) => record.Sns.MessageId ?? uuid(),
+  redactRecord: (record, redactedMessage) => ({
+    ...record,
+    Sns: {
+      ...record.Sns,
+      Message: redactedMessage,
+    },
+  }),
+};
+
+const SNS_EVENT_ADAPTER: EventAdapter<SNSEvent, SNSEventRecord> = {
+  extractRecords: (event) => event.Records,
+  createMockEvent: (records) => ({ Records: records }),
+  createMockRecord: (messageBody, index) =>
+    ({
+      EventVersion: '1.0',
+      EventSubscriptionArn: 'test-subscription',
+      EventSource: 'aws:sns',
+      Sns: {
+        SignatureVersion: '1',
+        Timestamp: new Date().toISOString(),
+        Signature: 'mock-signature',
+        SigningCertUrl: 'mock-cert-url',
+        MessageId: `test-message-${index}`,
+        Message: messageBody,
+        MessageAttributes: {},
+        Type: 'Notification',
+        UnsubscribeUrl: 'mock-unsubscribe-url',
+        TopicArn: 'test-topic-arn',
+        Subject: null,
+      },
+    } as any),
+  getLogMessage: () => 'Processing SNS topic message',
+  getHandlerName: () => 'SNSMessageHandler',
+};
+
+/**
+ * An abstraction for an SNS message handler.
+ */
+export class SNSMessageHandler<Message, Context> extends MessageHandlerBase<
+  SNSEvent,
+  SNSEventRecord,
+  Message,
+  Context
+> {
+  constructor(config: SNSMessageHandlerConfig<Message, Context>) {
+    super(config, SNS_RECORD_EXTRACTOR, SNS_EVENT_ADAPTER);
+  }
+
+  /**
+   * Adds a message action to the handler.
+   *
+   * @param handler The handler, for additional chaining.
+   */
+  onMessage(
+    action: SNSMessageAction<Message, Context>,
+  ): SNSMessageHandler<Message, Context> {
+    this.addAction(action);
+    return this;
+  }
+
+  harness(
+    options: SNSMessageHandlerHarnessOptions<Message, Context>,
+  ): SNSMessageHandlerHarnessContext<Message> {
+    return super.harness(options, SNSMessageHandler);
+  }
+}

--- a/src/sqs.ts
+++ b/src/sqs.ts
@@ -1,128 +1,66 @@
+import { SQSEvent, SQSRecord } from 'aws-lambda';
 import { v4 as uuid } from 'uuid';
-import { SQSEvent, Context as AWSContext, SQSRecord } from 'aws-lambda';
-import bunyan from 'bunyan';
-import get from 'lodash/get';
 import {
-  BaseContext,
-  BaseHandlerConfig,
-  PartialBatchResponse,
-  handleUnprocessedRecords,
-  processWithOrdering,
-  withHealthCheckHandling,
-} from './utils';
-import { publicEncrypt } from 'crypto';
-import { LoggerInterface } from './logging';
+  EventAdapter,
+  MessageAction,
+  MessageHandlerBase,
+  MessageHandlerConfig,
+  MessageHandlerHarnessContext,
+  MessageHandlerHarnessOptions,
+  RecordExtractor,
+} from './message-handler-base';
 
-export type SQSMessageHandlerConfig<Message, Context> =
-  BaseHandlerConfig<Context> & {
-    /**
-     * A function for parsing SQS messages into your custom type.
-     */
-    parseMessage: (body: string) => Message;
+export type SQSMessageHandlerConfig<Message, Context> = MessageHandlerConfig<
+  Message,
+  Context
+>;
 
-    redactionConfig?: {
-      /**
-       * This will be called to redact the message body before logging it. By
-       * default, the full message body is logged.
-       */
-      redactMessageBody: (body: string) => string;
+export type SQSMessageAction<Message, Context> = MessageAction<
+  Message,
+  Context
+>;
 
-      /**
-       * The public encryption key used for writing messages that contain
-       * sensitive information but failed to be redacted.
-       */
-      publicEncryptionKey: string;
+export type SQSMessageHandlerHarnessOptions<Message, Context> =
+  MessageHandlerHarnessOptions<Message, Context>;
 
-      /**
-       * Logged with the encypted message to help identify the key used. For
-       * example, this could explain who has access to the key or how to get it.
-       */
-      publicKeyDescription: string;
-    };
+export type SQSMessageHandlerHarnessContext<Message> =
+  MessageHandlerHarnessContext<Message>;
 
-    /**
-     * Whether to ignore messages that fail to parse. If set to true,
-     * throwing in the custom parsing function will cause the message
-     * to be ignored, and never processed.
-     */
-    ignoreUnparseableMessages?: boolean;
-  };
-
-export type SQSMessageAction<Message, Context> = (
-  context: Context & BaseContext,
-  message: Message,
-) => void | Promise<void>;
-
-export type SQSMessageHandlerHarnessOptions<Message, Context> = {
-  /**
-   * A function for stringifying messages.
-   */
-  stringifyMessage: (message: Message) => string;
-
-  /**
-   * An optional override for the logger.
-   */
-  logger?: LoggerInterface;
-
-  /**
-   * An optional override for creating the run context.
-   */
-  createRunContext?: () => Context | Promise<Context>;
+const SQS_RECORD_EXTRACTOR: RecordExtractor<SQSRecord> = {
+  extractMessage: (record) => record.body,
+  extractMessageId: (record) => record.messageId,
+  extractOrderingKey: (record) => record.attributes.MessageGroupId ?? uuid(),
+  redactRecord: (record, redactedMessage) => ({
+    ...record,
+    body: redactedMessage,
+  }),
 };
 
-export type SQSMessageHandlerHarnessContext<Message> = {
-  /** Sends the specified event through the handler. */
-  sendEvent: (event: { messages: Message[] }) => Promise<PartialBatchResponse>;
+const SQS_EVENT_ADAPTER: EventAdapter<SQSEvent, SQSRecord> = {
+  extractRecords: (event) => event.Records,
+  createMockEvent: (records) => ({ Records: records }),
+  createMockRecord: (messageBody) =>
+    ({
+      attributes: {},
+      messageId: uuid(),
+      body: messageBody,
+    } as any),
+  getLogMessage: () => 'Processing SQS topic message',
+  getHandlerName: () => 'SQSMessageHandler',
 };
-
-const safeRedactor =
-  (
-    logger: LoggerInterface,
-    redactionConfig: NonNullable<
-      SQSMessageHandlerConfig<any, any>['redactionConfig']
-    >,
-  ) =>
-  (body: string) => {
-    try {
-      return redactionConfig.redactMessageBody(body);
-    } catch (error) {
-      let encryptedBody;
-
-      // If redaction fails, then encrypt the message body and log it.
-      // Encryption allows for developers to decrypt the message if needed
-      // but does not log sensitive inforation the the log stream.
-      try {
-        encryptedBody = publicEncrypt(
-          redactionConfig.publicEncryptionKey,
-          Buffer.from(body),
-        ).toString('base64');
-      } catch (error) {
-        // If encryption fails, then log the encryption error and replace
-        // the body with dummy text.
-        logger.error({ error }, 'Failed to encrypt message body');
-        encryptedBody = '[ENCRYPTION FAILED]';
-      }
-
-      // Log the redaction error
-      logger.error(
-        {
-          error,
-          encryptedBody,
-          publicKeyDescription: redactionConfig.publicKeyDescription,
-        },
-        'Failed to redact message body',
-      );
-      return '[REDACTION FAILED]';
-    }
-  };
 
 /**
  * An abstraction for an SQS message handler.
  */
-export class SQSMessageHandler<Message, Context> {
-  private messageActions: SQSMessageAction<Message, Context>[] = [];
-
-  constructor(readonly config: SQSMessageHandlerConfig<Message, Context>) {}
+export class SQSMessageHandler<Message, Context> extends MessageHandlerBase<
+  SQSEvent,
+  SQSRecord,
+  Message,
+  Context
+> {
+  constructor(config: SQSMessageHandlerConfig<Message, Context>) {
+    super(config, SQS_RECORD_EXTRACTOR, SQS_EVENT_ADAPTER);
+  }
 
   /**
    * Adds a message action to the handler.
@@ -132,145 +70,13 @@ export class SQSMessageHandler<Message, Context> {
   onMessage(
     action: SQSMessageAction<Message, Context>,
   ): SQSMessageHandler<Message, Context> {
-    this.messageActions.push(action);
+    this.addAction(action);
     return this;
   }
 
-  lambda(): (
-    event: SQSEvent,
-    context: AWSContext,
-  ) => Promise<PartialBatchResponse> {
-    return withHealthCheckHandling(async (event, awsContext) => {
-      // 1. Setup the logger.
-      // The batch ID provides a way to correlate all messages that are processed together.
-      // This is particularly useful for correlating handled and unhandled records.
-      const batchId = uuid();
-
-      /* istanbul ignore next */
-      const logger =
-        this.config.logger ??
-        bunyan.createLogger({
-          batchId,
-          name: 'SQSMessageHandler',
-          requestId: awsContext.awsRequestId,
-        });
-
-      // 2. Process all the records.
-      const redactor = this.config.redactionConfig
-        ? safeRedactor(logger, this.config.redactionConfig)
-        : undefined;
-
-      const redactRecord = (record: SQSRecord): SQSRecord =>
-        redactor
-          ? {
-              ...record,
-              body: redactor(record.body),
-            }
-          : record;
-
-      const redactedEvent = redactor
-        ? {
-            ...event,
-            Records: event.Records.map(redactRecord),
-          }
-        : event;
-      logger.info({ event: redactedEvent }, 'Processing SQS topic message');
-
-      const { unprocessedRecords } = await processWithOrdering(
-        {
-          items: event.Records,
-          // If there is not a MessageGroupId, then we don't care about
-          // the ordering for the event. We can just generate a UUID for the
-          // ordering key.
-          orderBy: (record: SQSRecord) =>
-            record.attributes.MessageGroupId ?? uuid(),
-          concurrency: this.config.concurrency ?? 5,
-        },
-        async (record) => {
-          const messageLogger = logger.child({
-            messageId: record.messageId,
-          });
-
-          let parsedMessage: Message;
-          try {
-            parsedMessage = this.config.parseMessage(record.body);
-          } catch (err) {
-            messageLogger.error({ err }, 'Failed to parse message');
-            if (this.config.ignoreUnparseableMessages) {
-              messageLogger.warn(
-                'ignoreUnparseableMessages is set to true. Ignoring message.',
-              );
-              return;
-            }
-            throw err;
-          }
-
-          // Extracting the correlation ID from the message allows for
-          // multiple messages to be correlated together.
-          const correlationId = get(parsedMessage, 'correlationId', uuid());
-
-          // Context is built per message to support message-specific correlation IDs.
-          const context: BaseContext & Context = {
-            correlationId,
-            logger: messageLogger.child({ correlationId }),
-          } as any;
-
-          Object.assign(context, await this.config.createRunContext(context));
-
-          for (const action of this.messageActions) {
-            await action({ ...context }, parsedMessage);
-          }
-
-          context.logger.info('Successfully processed SQS message');
-        },
-      );
-
-      return handleUnprocessedRecords({
-        logger, // The base logger only logs the batch ID.
-        unprocessedRecords,
-        usePartialBatchResponses: !!this.config.usePartialBatchResponses,
-        getItemIdentifier: (record) => record.messageId,
-        redactRecord,
-      });
-    });
-  }
-
-  harness({
-    stringifyMessage,
-    ...overrides
-  }: SQSMessageHandlerHarnessOptions<
-    Message,
-    Context
-  >): SQSMessageHandlerHarnessContext<Message> {
-    // Make a copy of the handler.
-    let handler = new SQSMessageHandler({ ...this.config, ...overrides });
-    for (const action of this.messageActions) {
-      handler = handler.onMessage(action);
-    }
-    const lambda = handler.lambda();
-
-    return {
-      sendEvent: ({ messages }) => {
-        const event: SQSEvent = {
-          Records: messages.map(
-            (msg) =>
-              // We don't need to mock every field on this event -- there are lots.
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-              ({
-                attributes: {},
-                messageId: uuid(),
-                body: stringifyMessage(msg),
-              } as any),
-          ),
-        };
-
-        return lambda(
-          event,
-          // We don't need to mock every field on the context -- there are lots.
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-          { awsRequestId: uuid() } as any,
-        );
-      },
-    };
+  harness(
+    options: SQSMessageHandlerHarnessOptions<Message, Context>,
+  ): SQSMessageHandlerHarnessContext<Message> {
+    return super.harness(options, SQSMessageHandler);
   }
 }


### PR DESCRIPTION
Refactors SQS message handler to use a new base message handler class, then extends base class to add SNS message handler. These are very similar with subtle but important differences, so it made sense to reuse as much as possible.
